### PR TITLE
Profile Picture As Favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,22 +1,23 @@
-import type { Metadata } from "next";
-import { Analytics } from "@vercel/analytics/react";
-import data from "@/config";
-import ThemeContext from "@/context/themeContext";
-import "@/styles/global.css";
-import "@/styles/normalize.css";
+import type { Metadata } from 'next';
+import { Analytics } from '@vercel/analytics/react';
+import data from '@/config';
+import ThemeContext from '@/context/themeContext';
+import '@/styles/global.css';
+import '@/styles/normalize.css';
 
 export const metadata: Metadata = {
   title: data.title,
-  description: "A link board, like a bulletin board, but for links.",
+  icons: ['/profile.png'],
+  description: 'A link board, like a bulletin board, but for links.',
   authors: [
     {
-      name: "HangerThem",
-      url: "https://hangerthem.com",
+      name: 'HangerThem',
+      url: 'https://hangerthem.com',
     },
   ],
-  keywords: ["link", "board", "linkboard", "bulletin", "bulletin"],
-  creator: "HangerThem",
-  publisher: "HangerThem",
+  keywords: ['link', 'board', 'linkboard', 'bulletin', 'bulletin'],
+  creator: 'HangerThem',
+  publisher: 'HangerThem',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
I just added a quick line in `layout.tsx` to take `/public/profile.png` and use it as the favicon for the page. I just felt like something was missing without it 😄

In the future maybe changing things so the icon is something the user is specifically able to customize in `config.ts` but that's beyond the scope of my Next.js knowledge so just an idea I'm putting out there!