### PR TITLE
Jumping Text Fix Take 2

### DIFF
--- a/components/linkBoard/linkBoardStyles.ts
+++ b/components/linkBoard/linkBoardStyles.ts
@@ -74,6 +74,13 @@ export const Description = styled.p`
   font-weight: normal;
   margin: 0;
 
+  @media screen and (max-width: 408px) {
+    &::before,
+    &::after {
+      margin: 0 0.5rem !important;
+    }
+  }
+
   &::before,
   &::after {
     content: "-";


### PR DESCRIPTION
Right, let's try this again with the correct branch this time!

There was a minor bug where on certain mobile devices (once the screen size got small enough), with a long enough description, the margin which triggered the `-`'s to fly in from the side caused the text to break onto two lines and then jump back to a single line after the animation completed.

I just made a minor styling change to use a `0.5rem` margin instead of a `2.5rem` one if the screen size was less than 408px wide and seems to have fixed the issue!

Before:

https://github.com/user-attachments/assets/54c763bc-eebb-49b3-b061-f011367d8525


After:

https://github.com/user-attachments/assets/8ba59cf5-6996-4c5d-9507-4f9d858d4870


